### PR TITLE
Updating loader signature to match nunjucks.FileSystemLoader

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -4,7 +4,7 @@ var nunjucks = require('nunjucks');
 module.exports = nunjucks.FileSystemLoader.extend({
   init: function (extname, searchPaths, noWatch, noCache) {
     this.extname = extname;
-    this.parent(searchPaths, noWatch, noCache);
+    this.parent(searchPaths, {watch: !noWatch, noCache});
   },
   getSource: function (name) {
     return this.parent(name + this.extname);


### PR DESCRIPTION
Fixes the error

``` shell
[nunjucks] Warning: you passed a boolean as the second argument to FileSystemLoader, but it now takes an options object. See http://mozilla.github.io/nunjucks/api.html#filesystemloader
```